### PR TITLE
Made it possible to run the mod serverside only

### DIFF
--- a/src/main/java/theboo/mods/customrecipes/CustomRecipes.java
+++ b/src/main/java/theboo/mods/customrecipes/CustomRecipes.java
@@ -48,7 +48,7 @@ import cpw.mods.fml.common.registry.GameRegistry;
  * @author TheBoo
  *   
  */
-@Mod(modid = Reference.MOD_ID, name = Reference.MOD_NAME, version = Reference.VERSION_NUMBER, dependencies = Reference.DEPENDENCIES)
+@Mod(modid = Reference.MOD_ID, name = Reference.MOD_NAME, version = Reference.VERSION_NUMBER, dependencies = Reference.DEPENDENCIES, acceptableRemoteVersions="*")
 public class CustomRecipes {
 	
     public static net.minecraftforge.common.config.Configuration config;


### PR DESCRIPTION
added acceptableRemoteVersions="*" to @Mod annotation to allow clients to connect to servers using this mod.
This makes the mod great to extend modpacks without having the others to add this mod.
Allthough they won't see the output item in the crafting gui they can click into the empty slot to pull the item out or they install the mod on their client to fix that.